### PR TITLE
Added configuration option to enable or disable forced video deinterl…

### DIFF
--- a/TVHeadEnd/Configuration/PluginConfiguration.cs
+++ b/TVHeadEnd/Configuration/PluginConfiguration.cs
@@ -17,6 +17,7 @@ namespace TVHeadEnd.Configuration
         public string Profile { get; set; }
         public string ChannelType { get; set; }
         public bool EnableSubsMaudios { get; set; }
+        public bool ForceDeinterlace { get; set; }
 
         public PluginConfiguration()
         {
@@ -29,6 +30,7 @@ namespace TVHeadEnd.Configuration
             Profile = "";
             ChannelType = "Ignore";
             EnableSubsMaudios = false;
+            ForceDeinterlace = false;
         }
     }
 }

--- a/TVHeadEnd/Configuration/configPage.html
+++ b/TVHeadEnd/Configuration/configPage.html
@@ -75,6 +75,15 @@
                             </div>
                         </li>
                         <li>
+                            <label for="chkForceDeinterlace">
+                                Force video deinterlacing for all channels and recordings (EXPERIMENTAL)
+                            </label>
+                            <input type="checkbox" id="chkForceDeinterlace" />
+                            <div class="fieldDescription">
+                                Note: Configuration change requires Emby server restart.
+                            </div>
+                        </li>
+                        <li>
                             <button type="submit" data-theme="b">Save</button>
                             <button type="button" onclick="history.back();">Cancel</button>
                         </li>
@@ -103,6 +112,7 @@
                     $('#txtProfile', page).val(config.Profile || "");
                     $('#selChannelType', page).val(config.ChannelType || "Ignore");
                     $('#chkEnableSubsMaudios', page).checked(config.EnableSubsMaudios || false).checkboxradio("refresh");
+                    $('#chkForceDeinterlace', page).checked(config.ForceDeinterlace || false).checkboxradio("refresh");
                     Dashboard.hideLoadingMsg();
                 });
             });
@@ -120,6 +130,7 @@
                     config.Profile = $('#txtProfile', form).val();
                     config.ChannelType = $('#selChannelType', form).val();
                     config.EnableSubsMaudios = $('#chkEnableSubsMaudios', form).checked();
+                    config.ForceDeinterlace = $('#chkForceDeinterlace', form).checked();
                     ApiClient.updatePluginConfiguration(TVHclientConfigurationPageVar.pluginUniqueId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });
                 // Disable default form submission

--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -33,6 +33,7 @@ namespace TVHeadEnd
         private string _userName;
         private string _password;
         private bool _enableSubsMaudios;
+        private bool _forceDeinterlace;
 
         // Data helpers
         private readonly ChannelDataHelper _channelDataHelper;
@@ -122,6 +123,7 @@ namespace TVHeadEnd
             _profile = config.Profile.Trim();
             _channelType = config.ChannelType.Trim();
             _enableSubsMaudios = config.EnableSubsMaudios;
+            _forceDeinterlace = config.ForceDeinterlace;
 
             if (_priority < 0 || _priority > 4)
             {
@@ -238,6 +240,11 @@ namespace TVHeadEnd
         public bool GetEnableSubsMaudios()
         {
             return _enableSubsMaudios;
+        }
+
+        public bool GetForceDeinterlace()
+        {
+            return _forceDeinterlace;
         }
 
         public Task<IEnumerable<RecordingInfo>> BuildDvrInfos(CancellationToken cancellationToken)

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -416,6 +416,22 @@ namespace TVHeadEnd
                     // Probe the asset stream to determine available sub-streams
                     await ProbeStream(livetvasset, livetvasset_probeUrl, livetvasset_source, cancellationToken);
 
+                    // If enabled, force video deinterlacing for channels
+                    if(_htsConnectionHandler.GetForceDeinterlace())
+                    {
+                        
+                        _logger.Info("[TVHclient] Force video deinterlacing for all channels and recordings is enabled.");
+
+                        foreach (MediaStream i in livetvasset.MediaStreams)
+                        {
+                            if (i.Type == MediaStreamType.Video && i.IsInterlaced == false)
+                            {
+                                i.IsInterlaced = true;
+                            }
+                        }
+
+                    }
+
                     return livetvasset;
 
                 }
@@ -703,6 +719,22 @@ namespace TVHeadEnd
 
                     // Probe the asset stream to determine available sub-streams
                     await ProbeStream(recordingasset, recordingasset_probeUrl, recordingasset_source, cancellationToken);
+
+                    // If enabled, force video deinterlacing for recordings
+                    if (_htsConnectionHandler.GetForceDeinterlace())
+                    {
+
+                        _logger.Info("[TVHclient] Force video deinterlacing for all channels and recordings is enabled.");
+
+                        foreach (MediaStream i in recordingasset.MediaStreams)
+                        {
+                            if (i.Type == MediaStreamType.Video && i.IsInterlaced == false)
+                            {
+                                i.IsInterlaced = true;
+                            }
+                        }
+
+                    }
 
                     return recordingasset;
 


### PR DESCRIPTION
…acing for all channels and recordings

Hi Tolotos,

I did a small modification to the plugin to allow users to force video deinterlacing for all channels and recordings.
This is necessary since the addition of the stream probing feature is not probing for video interlacing (disabled by default) and many TV channels use interlacing to broadcast. This caused that in some players, the video will look fussy.
With this new option if the users are using stream probing, they can also force the video to be deinterlaced while transcoding to remove the interlacing effect and get a better picture quality.
I don't expect the change to create any issues but yet I marked the option as "experimental" in the configuration page.

Cheers,

Fer